### PR TITLE
Fix memory leak with VS R66+

### DIFF
--- a/vsengine/_hospice.py
+++ b/vsengine/_hospice.py
@@ -63,7 +63,7 @@ def unfreeze():
 
 
 def _is_core_still_used(ident: int) -> bool:
-    return sys.getrefcount(cores[ident]) > 2
+    return sys.getrefcount(cores[ident]) > 3
 
 
 def _add_tostage1(ident: int) -> None:


### PR DESCRIPTION
Quote from [here](https://discord.com/channels/1201920486187995156/1201920487223984220/1292233092668457075):
> There is currently a problem with vs-preview leaking memory [link](https://github.com/Jaded-Encoding-Thaumaturgy/vs-preview/issues/195)
I think the problem is with vs-engine since vapoursynth R66 [link](https://github.com/vapoursynth/vapoursynth/commit/08e8874649d0e82fc9d9c1ef296579151ac9a718) CoreTimings was added which adds a reference to Core, preventing it to be freed since a check in vs-engine now doesnt pass, i think.
This needs to be updated to 3 now ? But dunno I'm not really that familiar with vs-engine or python internals .
[link](https://github.com/Irrational-Encoding-Wizardry/vs-engine/blob/ddbb6284d4556c623c144f4a402e2665dccb0338/vsengine/_hospice.py#L66)

I've tested this patch before opening this PR and it seems to solve the memory leakage.